### PR TITLE
Restructure useAuction(s) hooks

### DIFF
--- a/src/hooks/useAuction.ts
+++ b/src/hooks/useAuction.ts
@@ -7,17 +7,39 @@ import { useAuctions } from './useAuctions'
 // Interfaces
 import { Auction } from 'src/interfaces/Auction'
 
+interface UseAuctionReturn {
+  loading: boolean
+  error: Error | null
+  auction: Auction | null
+}
+
 /**
  *
  * @param auctionId
  */
-export function useAuction(auctionId: string) {
-  const auctions = useAuctions()
-  const [auction, setAuctions] = useState<Auction>()
+export function useAuction(auctionId: string): UseAuctionReturn {
+  const { auctions } = useAuctions()
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<Error | null>(null)
+  const [auction, setAuctions] = useState<Auction | null>(null)
 
   useEffect(() => {
-    setAuctions(auctions.find(auction => auction.id === auctionId))
+    try {
+      const foundAuction = auctions.find(auction => auction.id === auctionId)
+
+      // Auction == null = not found
+      if (foundAuction) {
+        setAuctions(foundAuction)
+      }
+    } catch (e) {
+      setError(e)
+    }
+    setLoading(false)
   }, [auctions, auctionId])
 
-  return auction
+  return {
+    auction,
+    loading,
+    error,
+  }
 }

--- a/src/hooks/useAuctions.ts
+++ b/src/hooks/useAuctions.ts
@@ -8,7 +8,15 @@ import { generateAuctionData } from 'src/data/auction'
 // Interfaces
 import { Auction } from 'src/interfaces/Auction'
 
-export function useAuctions() {
+interface UseAuctionsReturn {
+  loading: boolean
+  error: Error | null
+  auctions: Auction[]
+}
+
+export function useAuctions(): UseAuctionsReturn {
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<Error | null>(null)
   const [auctions, setAuctions] = useState<Auction[]>([])
 
   useEffect(() => {
@@ -17,7 +25,12 @@ export function useAuctions() {
     // startBlock and endBlock assumes that there are 6000 blocks per 24 hours interval
     // push data once
     setAuctions(generateAuctionData(utcDate.unix()))
+    setLoading(false)
   }, [])
 
-  return auctions
+  return {
+    error,
+    loading,
+    auctions,
+  }
 }


### PR DESCRIPTION
Addressed in #42, the current return value of `useAuction` and `useAuctions` are vague. Hook consumer expects `Auction` and `Auction[]` for hooks, respectively. 

This works when there is no network call involved. In an actual implementation, `Auction` is fetched from subgraph nodes. Hence, it makes sense to add more explicit return values such as `loading`, `error` and move the main to `auction` object for `useAuction` and `auctions` for `useAuctions`.

The refactor allows the consumer to anticipate status changes. 
