### PR TITLE
Fix PlaceBidForm logic

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -19,7 +19,9 @@
     "noBidsMessage": "There are no bids",
     "runningAuctions": "Running Auctions",
     "upcomingAuctions": "Upcoming Auctions",
-    "calculatedVirtualPrice": "Virtual Settlement Price"
+    "calculatedVirtualPrice": "Virtual Settlement Price",
+    "bidMaybeTooLow": "Warning: Bid may be too low to be included",
+    "doYouWishToContinue": "Do you wish to continue?"
   },
   "buttons": {
     "back": "Back",

--- a/src/views/Auction/components/PlaceBidForm.tsx
+++ b/src/views/Auction/components/PlaceBidForm.tsx
@@ -20,15 +20,29 @@ interface BidData {
 interface PlaceBidComponentProps {
   auction: Auction
   onSubmit: (bidData: BidData) => void
-  reset?: () => void
-  CurrentSettlementPrice?: number
+  currentSettlementPrice?: number
 }
 
-export function PlaceBidForm({ auction, onSubmit, reset, CurrentSettlementPrice }: PlaceBidComponentProps) {
+export function PlaceBidForm({ auction, onSubmit, currentSettlementPrice }: PlaceBidComponentProps) {
   const [formValid, setFormValid] = useState<boolean>(false)
   const [tokenAmount, setTokenAmount] = useState<number>(0)
   const [tokenPrice, setTokenPrice] = useState<number>(0)
   const [t] = useTranslation()
+
+  const validateForm = (values: number[]) => setFormValid(values.every(value => value > 0))
+
+  /**
+   * Checks the bids place and warns the user if their bid is below
+   * @todo repalce `window.confirm` with a modal
+   */
+  const checkBidPrice = (currentSettlementPrice: number | undefined) => {
+    // Request user's confirmation if there is a bid already
+    if (currentSettlementPrice && tokenPrice <= currentSettlementPrice * 0.7) {
+      return window.confirm(`${t('texts.bidMaybeTooLow')}. ${t('texts.doYouWishToContinue')}?`)
+    }
+    // Proceed to continue
+    return true
+  }
 
   // Change handlers
   const onTokenPriceChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -43,33 +57,16 @@ export function PlaceBidForm({ auction, onSubmit, reset, CurrentSettlementPrice 
     validateForm([tokenAmount, tokenPrice])
   }
 
-  const validateForm = (values: number[]) => setFormValid(values.every(value => value > 0))
-
   // Submission handler
   const onFormSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    if (BidWarning(CurrentSettlementPrice) === true) {
+    if (checkBidPrice(currentSettlementPrice) === true) {
       onSubmit({
         tokenAmount,
         tokenPrice,
       })
-      reset && reset()
-    }
-    reset && reset()
-  }
-
-  const BidWarning = (CurrentSettlementPrice: number | undefined) => {
-    if (CurrentSettlementPrice) {
-      if (tokenPrice <= CurrentSettlementPrice * 0.7) {
-        if (window.confirm(t('Warning: Bid may be too low to be included'))) {
-          return true
-        } else {
-          return false
-        }
-      }
     }
   }
-
 
   return (
     <form id="createBidForm" onSubmit={onFormSubmit}>

--- a/src/views/Auction/components/PlaceBidForm.tsx
+++ b/src/views/Auction/components/PlaceBidForm.tsx
@@ -6,10 +6,10 @@ import { useTranslation } from 'react-i18next'
 import { FormGroup } from 'src/components/FormGroup'
 import { Button } from 'src/components/Button'
 
-//utils
+// Mesa Utils
 import { isAuctionClosed, isAuctionUpcoming } from 'src/mesa/auction'
 
-//interfaces
+// Interfaces
 import { Auction } from 'src/interfaces/Auction'
 
 interface BidData {

--- a/src/views/Auction/components/PlaceBidForm.tsx
+++ b/src/views/Auction/components/PlaceBidForm.tsx
@@ -38,7 +38,7 @@ export function PlaceBidForm({ auction, onSubmit, currentSettlementPrice }: Plac
   const checkBidPrice = (currentSettlementPrice: number | undefined) => {
     // Request user's confirmation if there is a bid already
     if (currentSettlementPrice && tokenPrice <= currentSettlementPrice * 0.7) {
-      return window.confirm(`${t('texts.bidMaybeTooLow')}. ${t('texts.doYouWishToContinue')}?`)
+      return window.confirm(`${t('texts.bidMaybeTooLow')}. ${t('texts.doYouWishToContinue')}`)
     }
     // Proceed to continue
     return true

--- a/src/views/Auction/index.tsx
+++ b/src/views/Auction/index.tsx
@@ -90,7 +90,7 @@ export function AuctionView() {
                   console.log('Add to Auction')
                 }}
                 auction={auction}
-                CurrentSettlementPrice={numeral(calculateClearingPrice(auction.bids)).value()}
+                currentSettlementPrice={numeral(calculateClearingPrice(auction.bids)).value()}
               />
             </CardBody>
           </Card>

--- a/src/views/Simulation/index.tsx
+++ b/src/views/Simulation/index.tsx
@@ -154,7 +154,7 @@ export function SimulationView() {
                   })
                 }
                 auction={auction}
-                CurrentSettlementPrice={clearingPrice?.sellAmount.toNumber()}
+                currentSettlementPrice={clearingPrice?.sellAmount.toNumber()}
               />
             </CardBody>
           </Card>


### PR DESCRIPTION
This PR addresses a few issues with `PlaceBidForm` from the previous PR.

## Description

 - Component prop `currentSettlementPrice` should use `camelCase`. 
 - Function `BidWarning` name should use `camelCase`. 
 - Function `BidWarning` should be descriptive: renamed to `checkBidPrice`
 - Removed unused `reset` props 
 - Fixed logic in `BidWarning`/`checkBidPrice`. There are few cases
   - There are no bids on the auctions
      - Return `true`. There is no need for the user's confirmation.
   - There are bids on the auction, and the user's bid price is:
        - Within 30% threshold from settlement/virtual price 
           - Return `true`. There is no need for the user's confirmation.
        - Outside 30% threshold from settlement/virtual price 
           - Ask for user's confirmation if they wish to proceed with the bid. 
        
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
