### PR TITLE
feature/network-warning

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -25,7 +25,7 @@
     "placeBid": "Place Bid",
     "salesType": "Sales Type",
     "currentPrice": "Current Price",
-    "minPrice": "Minumum Price",
+    "minPrice": "Minimum Price",
     "amountForSale": "Amount for Sale",
     "noBidsMessage": "There are no bids",
     "runningSales": "Running Sales",
@@ -35,7 +35,8 @@
     "doYouWishToContinue": "Do you wish to continue?",
     "yourActivity": "Your Activity",
     "placeBuyOrder": "Place Buy Order",
-    "pageNotFound": "The page that you’re looking for couldn’t be found."
+    "pageNotFound": "The page that you’re looking for couldn’t be found.",
+    "invalidNetwork": "Please connect to the xDai network"
   },
   "buttons": {
     "back": "Back",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -37,7 +37,7 @@
     "placeBuyOrder": "Place Buy Order",
     "pageNotFound": "The page that you’re looking for couldn’t be found.",
     "invalidNetwork": "Please connect to the xDai network",
-    "connectWallet": "Connect wallet to xdai network to participate"
+    "connectWallet": "Connect wallet to xDai network to participate"
   },
   "buttons": {
     "back": "Back",
@@ -46,6 +46,7 @@
     "addARandomBid": "Add A Random Bid",
     "showClosedSales": "Show Closed Sales",
     "hideClosedSales": "Hide Closed Sales",
-    "backToSales": "Back to all sales"
+    "backToSales": "Back to all sales",
+    "changeNetwork": "Change Network"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -36,7 +36,8 @@
     "yourActivity": "Your Activity",
     "placeBuyOrder": "Place Buy Order",
     "pageNotFound": "The page that you’re looking for couldn’t be found.",
-    "invalidNetwork": "Please connect to the xDai network"
+    "invalidNetwork": "Please connect to the xDai network",
+    "connectWallet": "Connect wallet to xdai network to participate"
   },
   "buttons": {
     "back": "Back",

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -5,11 +5,11 @@ import React from 'react'
 import { Wrapper, Content, CloseButtonImage } from './style'
 
 export interface BannerProps {
-  error: boolean
+  error?: boolean
   close?: () => void
 }
 
-export const Banner: React.FC<BannerProps> = ({ children, error, close }) => {
+export const Banner: React.FC<BannerProps> = ({ children, error = false, close }) => {
   return (
     <Wrapper error={error}>
       <Content>{children}</Content>

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -1,0 +1,19 @@
+// Externals
+import React from 'react'
+
+// Internal
+import { Wrapper, Content, CloseButtonImage } from './style'
+
+export interface BannerProps {
+  error: boolean
+  close?: () => void
+}
+
+export const Banner: React.FC<BannerProps> = ({ children, error, close }) => {
+  return (
+    <Wrapper error={error}>
+      <Content>{children}</Content>
+      {close && <CloseButtonImage onClick={close} />}
+    </Wrapper>
+  )
+}

--- a/src/components/Banner/style.tsx
+++ b/src/components/Banner/style.tsx
@@ -14,7 +14,7 @@ export const Wrapper = styled.div<WrapperProps>(props => ({
   justifyContent: 'center',
   alignItems: 'center',
   backgroundColor: props.error ? '#E15F5F' : 'white',
-  color: 'white',
+  color: props.error ? 'white' : 'black',
 }))
 
 export const Content = styled.div({

--- a/src/components/Banner/style.tsx
+++ b/src/components/Banner/style.tsx
@@ -17,15 +17,6 @@ export const Wrapper = styled.div<WrapperProps>(props => ({
   color: 'white',
 }))
 
-// backgroundColor: props.error ? 'rgba(225, 95, 95, 0.35)' : 'white',
-// color: 'black',
-
-// backgroundColor: 'white',
-// color: props.error ? '#E15F5F' : 'white',
-
-// backgroundColor: props.error ? '#E15F5F' : 'white',
-// color: 'white',
-
 export const Content = styled.div({
   flex: '1',
   textAlign: 'center',

--- a/src/components/Banner/style.tsx
+++ b/src/components/Banner/style.tsx
@@ -1,0 +1,43 @@
+// Externals
+import styled from 'styled-components'
+// Svg
+import CloseImg from 'src/assets/svg/Close.svg'
+
+export interface WrapperProps {
+  error: boolean
+}
+
+export const Wrapper = styled.div<WrapperProps>(props => ({
+  height: '8vh',
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  backgroundColor: props.error ? '#E15F5F' : 'white',
+  color: 'white',
+}))
+
+// backgroundColor: props.error ? 'rgba(225, 95, 95, 0.35)' : 'white',
+// color: 'black',
+
+// backgroundColor: 'white',
+// color: props.error ? '#E15F5F' : 'white',
+
+// backgroundColor: props.error ? '#E15F5F' : 'white',
+// color: 'white',
+
+export const Content = styled.div({
+  flex: '1',
+  textAlign: 'center',
+})
+
+export const CloseButtonImage = styled.img({
+  width: '16px',
+  height: '16px',
+  margin: '0px 25px',
+  cursor: 'pointer',
+})
+
+CloseButtonImage.defaultProps = {
+  src: CloseImg,
+}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -25,6 +25,7 @@ import {
   MobileMenu,
   MenuOption,
   MenuBorder,
+  ColumnWrapper,
 } from './style'
 
 // Components
@@ -189,7 +190,7 @@ export const Header: React.FC = () => {
   }
 
   return (
-    <div>
+    <ColumnWrapper>
       {!isValidNetwork && (
         <Banner error>
           {t('texts.invalidNetwork')}
@@ -218,6 +219,6 @@ export const Header: React.FC = () => {
           {account && <ButtonImage />}
         </Button>
       </Wrapper>
-    </div>
+    </ColumnWrapper>
   )
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -43,7 +43,7 @@ export const Header: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState<boolean>(false)
   const { account, activate, deactivate } = useWeb3React()
   const { isMobile } = useWindowSize()
-  const isValidNetwork = useSelector(store => (store.network.invalidChainId ? false : true))
+  const isValidNetwork = useSelector(store => store.network.validChainId)
   const dispatch = useDispatch()
 
   const walletAddress = account ? `${account.substr(0, 6)}...${account.substr(-4)}` : ''
@@ -54,9 +54,9 @@ export const Header: React.FC = () => {
     const parsedChainId = parseInt(chainId, 16)
     const isChainSupported = SUPPORTED_CHAIN_IDS.includes(parsedChainId)
     if (!isChainSupported) {
-      dispatch(setInvalidChainId(parsedChainId))
+      dispatch(setInvalidChainId())
     } else {
-      dispatch(setValidChainId(parsedChainId))
+      dispatch(setValidChainId())
     }
   }
 

--- a/src/components/Header/style.tsx
+++ b/src/components/Header/style.tsx
@@ -13,6 +13,14 @@ import {
 // Svg
 import DownArrowUrl from 'src/assets/svg/Down-Arrow.svg'
 
+export const ColumnWrapper = styled.div<SpaceProps & ColorProps>(() => ({
+  zIndex: 100,
+  width: '100%',
+  outline: '0',
+  display: 'flex',
+  flexDirection: 'column',
+}))
+
 export const Wrapper = styled.div<SpaceProps & ColorProps>(
   () => ({
     height: '72px',

--- a/src/components/Header/style.tsx
+++ b/src/components/Header/style.tsx
@@ -118,7 +118,7 @@ export type ButtonProps = {
   LayoutProps &
   JustifyContentProps
 
-export const Button = styled.div<ButtonProps>(
+export const Button = styled.button<ButtonProps>(
   ({ backgroundColor, textColor = 'white' }) => ({
     backgroundColor,
     display: 'flex',
@@ -134,6 +134,7 @@ export const Button = styled.div<ButtonProps>(
     alignItems: 'center',
     justifyContent: 'space-between',
     cursor: 'pointer',
+    border: 'none',
   }),
   space,
   layout,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,6 +9,7 @@ export const SUBGRAPH_ENDPOINT = process.env.REACT_APP_SUBGRAPH_ENDPOINT as stri
 export const FE_VERSION = '0.0.1'
 export const SC_VERSION = '0.0.1'
 export const NETWORK_CONTEXT_NAME = 'Network'
+export const SUPPORTED_CHAIN_IDS = [100]
 export enum CHAIN_ID {
   MAINNET = 1,
   RINKEBY = 4,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -15,3 +15,14 @@ export enum CHAIN_ID {
   RINKEBY = 4,
   XDAI = 100,
 }
+export const XDAI_CHAIN_PARAMETER = {
+  chainId: '0x64',
+  chainName: 'xDai',
+  nativeCurrency: {
+    name: 'xDai',
+    symbol: 'xDai',
+    decimals: 18,
+  },
+  rpcUrls: ['https://rpc.xdaichain.com/'],
+  blockExplorerUrls: ['https://blockscout.com/xdai/mainnet'],
+}

--- a/src/redux/network/index.test.ts
+++ b/src/redux/network/index.test.ts
@@ -1,0 +1,42 @@
+// Externals
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+// components
+import { reducer, ActionTypes, NetworkAction, NetworkState } from './index'
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares)
+const store = mockStore({})
+
+describe('Network Actions and Reducers', () => {
+  const initialState: NetworkState = {
+    validChainId: null,
+    invalidChainId: null,
+  }
+
+  afterEach(() => {
+    store.clearActions()
+  })
+
+  test('reducer should handle NETWORK_SET_VALID_CHAIN_ID', () => {
+    const startAction: NetworkAction = {
+      type: ActionTypes.NETWORK_SET_VALID_CHAIN_ID,
+      payload: 100,
+    }
+    expect(reducer(initialState, startAction)).toEqual({
+      validChainId: 100,
+      invalidChainId: null,
+    })
+  }),
+    test('reducer should handle NETWORK_SET_INVALID_CHAIN_ID', () => {
+      const startAction: NetworkAction = {
+        type: ActionTypes.NETWORK_SET_INVALID_CHAIN_ID,
+        payload: 1,
+      }
+      expect(reducer(initialState, startAction)).toEqual({
+        validChainId: null,
+        invalidChainId: 1,
+      })
+    })
+})

--- a/src/redux/network/index.test.ts
+++ b/src/redux/network/index.test.ts
@@ -11,8 +11,7 @@ const store = mockStore({})
 
 describe('Network Actions and Reducers', () => {
   const initialState: NetworkState = {
-    validChainId: null,
-    invalidChainId: null,
+    validChainId: true,
   }
 
   afterEach(() => {
@@ -22,21 +21,17 @@ describe('Network Actions and Reducers', () => {
   test('reducer should handle NETWORK_SET_VALID_CHAIN_ID', () => {
     const startAction: NetworkAction = {
       type: ActionTypes.NETWORK_SET_VALID_CHAIN_ID,
-      payload: 100,
     }
     expect(reducer(initialState, startAction)).toEqual({
-      validChainId: 100,
-      invalidChainId: null,
+      validChainId: true,
     })
   }),
     test('reducer should handle NETWORK_SET_INVALID_CHAIN_ID', () => {
       const startAction: NetworkAction = {
         type: ActionTypes.NETWORK_SET_INVALID_CHAIN_ID,
-        payload: 1,
       }
       expect(reducer(initialState, startAction)).toEqual({
-        validChainId: null,
-        invalidChainId: 1,
+        validChainId: false,
       })
     })
 })

--- a/src/redux/network/index.ts
+++ b/src/redux/network/index.ts
@@ -1,0 +1,47 @@
+import { Action } from 'redux'
+
+export enum ActionTypes {
+  NETWORK_SET_VALID_CHAIN_ID = 'NETWORK_SET_VALID_CHAIN_ID',
+  NETWORK_SET_INVALID_CHAIN_ID = 'NETWORK_SET_INVALID_CHAIN_ID',
+}
+
+interface NetworkActionSetValidChainId extends Action<ActionTypes.NETWORK_SET_VALID_CHAIN_ID> {
+  payload: number
+}
+
+interface NetworkActionSetInvalidChainId extends Action<ActionTypes.NETWORK_SET_INVALID_CHAIN_ID> {
+  payload: number
+}
+
+export type NetworkAction = NetworkActionSetValidChainId | NetworkActionSetInvalidChainId
+
+export type NetworkState = {
+  validChainId: number | null
+  invalidChainId: number | null
+}
+
+export const setValidChainId = (chainId: number): NetworkActionSetValidChainId => ({
+  type: ActionTypes.NETWORK_SET_VALID_CHAIN_ID,
+  payload: chainId,
+})
+
+export const setInvalidChainId = (chainId: number): NetworkActionSetInvalidChainId => ({
+  type: ActionTypes.NETWORK_SET_INVALID_CHAIN_ID,
+  payload: chainId,
+})
+
+export const initialState: NetworkState = {
+  validChainId: null,
+  invalidChainId: null,
+}
+
+export function reducer(state: NetworkState = initialState, action: NetworkAction) {
+  switch (action.type) {
+    case ActionTypes.NETWORK_SET_VALID_CHAIN_ID:
+      return { ...state, validChainId: action.payload, invalidChainId: null }
+    case ActionTypes.NETWORK_SET_INVALID_CHAIN_ID:
+      return { ...state, invalidChainId: action.payload, validChainId: null }
+    default:
+      return state
+  }
+}

--- a/src/redux/network/index.ts
+++ b/src/redux/network/index.ts
@@ -5,42 +5,33 @@ export enum ActionTypes {
   NETWORK_SET_INVALID_CHAIN_ID = 'NETWORK_SET_INVALID_CHAIN_ID',
 }
 
-interface NetworkActionSetValidChainId extends Action<ActionTypes.NETWORK_SET_VALID_CHAIN_ID> {
-  payload: number
-}
-
-interface NetworkActionSetInvalidChainId extends Action<ActionTypes.NETWORK_SET_INVALID_CHAIN_ID> {
-  payload: number
-}
-
-export type NetworkAction = NetworkActionSetValidChainId | NetworkActionSetInvalidChainId
+export type NetworkAction =
+  | Action<ActionTypes.NETWORK_SET_VALID_CHAIN_ID>
+  | Action<ActionTypes.NETWORK_SET_INVALID_CHAIN_ID>
 
 export type NetworkState = {
-  validChainId: number | null
-  invalidChainId: number | null
+  validChainId: boolean
 }
 
-export const setValidChainId = (chainId: number): NetworkActionSetValidChainId => ({
+export const setValidChainId = (): Action<ActionTypes.NETWORK_SET_VALID_CHAIN_ID> => ({
   type: ActionTypes.NETWORK_SET_VALID_CHAIN_ID,
-  payload: chainId,
 })
 
-export const setInvalidChainId = (chainId: number): NetworkActionSetInvalidChainId => ({
+export const setInvalidChainId = (): Action<ActionTypes.NETWORK_SET_INVALID_CHAIN_ID> => ({
   type: ActionTypes.NETWORK_SET_INVALID_CHAIN_ID,
-  payload: chainId,
 })
 
+// Initial validChainId state set to true to avoid initial render of warning
 export const initialState: NetworkState = {
-  validChainId: null,
-  invalidChainId: null,
+  validChainId: true,
 }
 
 export function reducer(state: NetworkState = initialState, action: NetworkAction) {
   switch (action.type) {
     case ActionTypes.NETWORK_SET_VALID_CHAIN_ID:
-      return { ...state, validChainId: action.payload, invalidChainId: null }
+      return { ...state, validChainId: true }
     case ActionTypes.NETWORK_SET_INVALID_CHAIN_ID:
-      return { ...state, invalidChainId: action.payload, validChainId: null }
+      return { ...state, validChainId: false }
     default:
       return state
   }

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -6,6 +6,7 @@ import Thunk, { ThunkAction } from 'redux-thunk'
 import { reducer as sales } from './sales'
 import { reducer as bids } from './bids'
 import { reducer as page } from './page'
+import { reducer as network } from './network'
 
 // Extend the RootState for useSelector
 declare module 'react-redux' {
@@ -17,6 +18,7 @@ const rootReducer = combineReducers({
   page,
   bids,
   sales,
+  network,
 })
 
 export type RootState = ReturnType<typeof rootReducer>

--- a/src/views/Sale/components/PurchaseTokensForm/index.tsx
+++ b/src/views/Sale/components/PurchaseTokensForm/index.tsx
@@ -4,6 +4,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { useWeb3React } from '@web3-react/core'
 import styled from 'styled-components'
 import { utils } from 'ethers'
+import { useTranslation } from 'react-i18next'
 
 // Components
 import { FormGroup } from 'src/components/FormGroup'
@@ -115,6 +116,7 @@ const w: any = window
 w.utils = utils
 
 export const PurchaseTokensForm = ({ saleId }: PurchaseTokensFormComponentProps) => {
+  const [t] = useTranslation()
   const [txPending, setTxPending] = useState(false)
   const { account, library } = useWeb3React()
   const { loading, sale, error } = useFixedPriceSaleQuery(saleId)
@@ -213,7 +215,7 @@ export const PurchaseTokensForm = ({ saleId }: PurchaseTokensFormComponentProps)
   )
 
   if (!account) {
-    return <Center>Connect wallet to particpate</Center>
+    return <Center>{t('texts.connectWallet')}</Center>
   }
 
   if (loading) {

--- a/src/views/Sales/index.tsx
+++ b/src/views/Sales/index.tsx
@@ -121,7 +121,7 @@ export function SalesView() {
 
   return (
     <SaleContext.Provider value={{ SaleShow, setSaleShow }}>
-      <AbsoluteContainer inner={false} noPadding={true}>
+      <AbsoluteContainer minHeight="100%" inner={false} noPadding={true}>
         <Header />
         <Container>
           <Title>Token Sales</Title>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Changed the initial message on the purchase token form.
- Added a banner component in Header that listens for chain changes on ethereum object and displays error banner if an unsupported chain is being used.
- Colours and UI elements all taken from figma.
- I also added error and close props which allow for normal closable banners to be used with the same component that look more like the existing figma banner.
- Changes are stored globally in redux. 
- Button uses metamask RPC API to add/connect to xDai network

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#193 
#197 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit testing for redux changes.
Tested locally using start-xdai and connecting to multiple networks via metamask.
Also tested on a browser with no metamask and banner displayed as expected with no errors.

## Screenshots:
<img width="1436" alt="Network banner screenshot" src="https://user-images.githubusercontent.com/39137239/120825879-bc78fa80-c551-11eb-9c8f-beb79bd1c6e6.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
