### PR TITLE
Fix glitch in timer when loading a sale.

### DIFF
--- a/src/views/Sale/FairSale.tsx
+++ b/src/views/Sale/FairSale.tsx
@@ -155,7 +155,7 @@ export function FairSaleView() {
                       <HeaderItem
                         isMobile
                         title="Ends In"
-                        description={secondsTohms(sale.endDate)}
+                        description=""
                         textAlign="right"
                         saleLive={true}
                         sale={sale}
@@ -186,7 +186,7 @@ export function FairSaleView() {
                     {isSaleOpen(sale) && (
                       <HeaderItem
                         title="Ends In"
-                        description={secondsTohms(sale.endDate)}
+                        description=""
                         textAlign="right"
                         saleLive={true}
                         sale={sale}

--- a/src/views/Sale/FairSale.tsx
+++ b/src/views/Sale/FairSale.tsx
@@ -40,7 +40,7 @@ import { BarChart } from './components/BarChart'
 // Mesa Utils
 import { calculateClearingPrice } from 'src/mesa/price'
 import { isSaleClosed, isSaleOpen, isSaleUpcoming } from 'src/mesa/sale'
-import { secondsTohms, timeEnd } from 'src/views/Sale/components/Timer'
+import { timeEnd } from 'src/views/Sale/components/Timer'
 import { formatBigInt } from 'src/utils/Defaults'
 
 // Wallet Utils

--- a/src/views/Sale/FixedPrice.tsx
+++ b/src/views/Sale/FixedPrice.tsx
@@ -37,7 +37,7 @@ import { Center } from 'src/layouts/Center'
 
 // Mesa Utils
 import { isSaleClosed, isSaleOpen, isSaleUpcoming } from 'src/mesa/sale'
-import { timeEnd, secondsTohms } from 'src/views/Sale/components/Timer'
+import { timeEnd } from 'src/views/Sale/components/Timer'
 import { formatBigInt } from 'src/utils/Defaults'
 
 // Views

--- a/src/views/Sale/FixedPrice.tsx
+++ b/src/views/Sale/FixedPrice.tsx
@@ -131,7 +131,7 @@ export function FixedPriceSaleView() {
                       <HeaderItem
                         isMobile
                         title="Ends In"
-                        description={secondsTohms(sale.endDate)}
+                        description=""
                         textAlign="right"
                         saleLive={true}
                         sale={sale as FIX_LATER}
@@ -163,7 +163,7 @@ export function FixedPriceSaleView() {
                     {isSaleOpen(sale as FIX_LATER) && (
                       <HeaderItem
                         title="Ends In"
-                        description={secondsTohms(sale.endDate)}
+                        description=""
                         textAlign="right"
                         saleLive={true}
                         sale={sale as FIX_LATER}

--- a/src/views/Sale/components/HeaderItem/index.tsx
+++ b/src/views/Sale/components/HeaderItem/index.tsx
@@ -77,15 +77,20 @@ export function HeaderItem({
   const [, setTime] = useState<number>(0)
   const [descriptionText, setDescriptionText] = useState<string>(description)
 
+  const runTimer = () => {
+    if (!saleLive || !sale) return
+
+    setTime(PrevTime => (PrevTime + 1) % 2)
+    const localTimeStamp = dayjs(Date.now()).unix()
+    const timeDiffEnd = Math.abs(localTimeStamp - convertUtcTimestampToLocal(sale.endDate))
+    setDescriptionText(secondsTohms(timeDiffEnd))
+  }
+
   // re-renders component every second
   useEffect(() => {
     if (saleLive && sale) {
-      const interval = setInterval(() => {
-        setTime(PrevTime => (PrevTime + 1) % 2)
-        const localTimeStamp = dayjs(Date.now()).unix()
-        const timeDiffEnd = Math.abs(localTimeStamp - convertUtcTimestampToLocal(sale.endDate))
-        setDescriptionText(secondsTohms(timeDiffEnd))
-      }, 1000)
+      runTimer()
+      const interval = setInterval(runTimer, 1000)
 
       return () => {
         clearInterval(interval)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Avoid passing the sale `endDate` as the initial value to render to the timer.
- Extract the timer tick to a separate function.
- Trigger the tick function before setting up `setInterval`, to set the initial value.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#207 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally using start-xdai.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
