### PR TITLE
fixing css, decimal and max allocation issues

### DIFF
--- a/src/views/Sale/FairSale.tsx
+++ b/src/views/Sale/FairSale.tsx
@@ -89,7 +89,7 @@ export function FairSaleView() {
   const [t] = useTranslation()
   const theme = useTheme()
 
-  const { error, loading, sale } = useSale(params.saleId)
+  const { sale } = useSale(params.saleId)
   const bids = useSelector(({ bids }) => bids.bidsBySaleId[params.saleId].bids || []) as FairSaleBid[]
 
   const toggleGraph = () => {

--- a/src/views/Sale/FairSale.tsx
+++ b/src/views/Sale/FairSale.tsx
@@ -89,7 +89,7 @@ export function FairSaleView() {
   const [t] = useTranslation()
   const theme = useTheme()
 
-  const { sale } = useSale(params.saleId)
+  const { error, loading, sale } = useSale(params.saleId)
   const bids = useSelector(({ bids }) => bids.bidsBySaleId[params.saleId].bids || []) as FairSaleBid[]
 
   const toggleGraph = () => {

--- a/src/views/Sale/components/PurchaseTokensForm/index.tsx
+++ b/src/views/Sale/components/PurchaseTokensForm/index.tsx
@@ -24,7 +24,7 @@ import { Center } from 'src/layouts/Center'
 import { FixedPriceSale__factory } from 'src/contracts'
 import { getProviderOrSigner } from 'src/utils'
 import { LinkedButtons } from 'src/components/LinkedButtons'
-import { formatBigInt, formatDecimal, fromBigDecimalToBigInt } from 'src/utils/Defaults'
+import { fromBigDecimalToBigInt } from 'src/utils/Defaults'
 
 const FormLabel = styled.div({
   fontStyle: 'normal',
@@ -135,7 +135,7 @@ export const PurchaseTokensForm = ({ saleId }: PurchaseTokensFormComponentProps)
       purchaseValue = tokenPrice.mul(newTokenAmount)
     }
 
-    // tokeAmount is less than minimum allocation
+    // tokenAmount is less than minimum allocation
     if (purchaseMinimumAllocation.gt(bigTokenAmount)) {
       newValidationError = new Error(`Token amount is less than ${utils.formatUnits(sale?.allocationMin)}`)
     }
@@ -152,7 +152,7 @@ export const PurchaseTokensForm = ({ saleId }: PurchaseTokensFormComponentProps)
     }
 
     // Update Component state and re-render
-    setTokenAmount(parseFloat(event.target.value)) // Convert back to number
+    setTokenAmount(newTokenAmount) // Convert back to number
     setValidationError(newValidationError)
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixed CSS solution that wouldn't show cursor in input form
- Added error for going over max allocation
- Fixed decimal issue that would cause BigNumber underflow
Decimal issue was difficult to fix due to ethers.js BigNumber not easily allowing multiplication by fractions. This solution works currently to one decimal place accuracy which I think is fine for just checking against min max allocation and wallet balance. The calculation is not used for actually buying the tokens. 
If you have a better/more obvious solution that I missed, please let me know.

<!--- Describe your changes in detail -->

## Motivation and Context
#218 
#214

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Locally on xdai inputting:
1, 0.5, 0.3, 1.3, 2.6, 10
and completing purchase with fractional tokens

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![2021-06-10 11 55 42](https://user-images.githubusercontent.com/39137239/121513489-cdf35400-c9e2-11eb-9f32-dad416ca74f1.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
