### PR TITLE
Changed input to take xdai and calculate quantity

### DIFF
--- a/src/components/LinkedButtons/index.tsx
+++ b/src/components/LinkedButtons/index.tsx
@@ -16,10 +16,11 @@ interface ButtonObject {
 interface LinkedButtonsProps {
   buttons: ButtonObject[]
   active: string
+  disabled?: boolean
   loading?: boolean
 }
 
-export const LinkedButtons: React.FC<LinkedButtonsProps> = ({ buttons, active, loading = false }) => {
+export const LinkedButtons: React.FC<LinkedButtonsProps> = ({ buttons, active, loading = false, disabled = false }) => {
   const [arrayOfButtons, setArrayOfButtons] = useState<Array<React.ReactNode>>([])
   const [progressLineArray, setProgressLineArray] = useState<Array<React.ReactNode>>([])
   const numberOfButtons = buttons.length
@@ -35,7 +36,11 @@ export const LinkedButtons: React.FC<LinkedButtonsProps> = ({ buttons, active, l
         beforeActive = false
       }
       tempButtons.push(
-        <StyledButton buttonSize={`${buttonSize}%`} onClick={button.onClick} disabled={!(button.id == active)}>
+        <StyledButton
+          buttonSize={`${buttonSize}%`}
+          onClick={button.onClick}
+          disabled={!(button.id == active) || disabled}
+        >
           {button.title}
           {loading && button.id == active && <Spinner size="10px" color="white" />}
         </StyledButton>

--- a/src/components/LinkedButtons/style.tsx
+++ b/src/components/LinkedButtons/style.tsx
@@ -10,7 +10,7 @@ export const ColumnWrapper = styled.div<SpaceProps & ColorProps>(() => ({
   outline: '0',
   display: 'flex',
   flexDirection: 'column',
-  margin: '20px 0',
+  marginBottom: '16px',
 }))
 
 export const Wrapper = styled.div<SpaceProps & ColorProps>(() => ({

--- a/src/views/Sale/components/PurchaseTokensForm/index.tsx
+++ b/src/views/Sale/components/PurchaseTokensForm/index.tsx
@@ -130,14 +130,10 @@ export const PurchaseTokensForm = ({ saleId }: PurchaseTokensFormComponentProps)
     let newValidationError = undefined
     const parsedTokenBalance = parseFloat(utils.formatUnits(tokenBalance))
     // Convert min max allocations
+    // Converting BigNumbers to normal numbers due to lack of decimal support
     const purchaseMinimumAllocation = parseFloat(utils.formatUnits(BigNumber.from(sale?.allocationMin)))
     const purchaseMaximumAllocation = parseFloat(utils.formatUnits(BigNumber.from(sale?.allocationMax)))
-    // Convert sale.tokenPrice to BigNumber for accurate math operations
-    // It also avoids dealing with native JavaScript operations
     const tokenPrice = parseFloat(utils.formatUnits(BigNumber.from(sale?.tokenPrice)))
-    // console.log(utils.parseEther(tokenPrice.toString()).toString())
-    // console.log(utils.formatUnits(tokenPrice))
-    // console.log(utils.parseUnits(tokenPrice.toString()).toString())
 
     const newPurchaseValue = parseFloat(event.target.value)
 
@@ -156,7 +152,7 @@ export const PurchaseTokensForm = ({ saleId }: PurchaseTokensFormComponentProps)
     }
 
     // Update Component state and re-render
-    setPurchaseValue(newPurchaseValue) // Convert back to number
+    setPurchaseValue(newPurchaseValue)
     setTokenQuantity(quantity)
     setValidationError(newValidationError)
   }

--- a/src/views/Sale/components/PurchaseTokensForm/index.tsx
+++ b/src/views/Sale/components/PurchaseTokensForm/index.tsx
@@ -141,10 +141,18 @@ export const PurchaseTokensForm = ({ saleId }: PurchaseTokensFormComponentProps)
 
     // purchaseValue is less than minimum allocation
     if (purchaseMinimumAllocation > quantity) {
-      newValidationError = new Error(`Token amount is less than ${utils.formatUnits(sale?.allocationMin)}`)
+      newValidationError = new Error(
+        `Minimum is ${purchaseMinimumAllocation * tokenPrice} ${sale?.tokenIn.symbol} / ${utils.formatUnits(
+          sale?.allocationMin
+        )} ${sale?.tokenOut.symbol}`
+      )
     }
     if (purchaseMaximumAllocation < quantity) {
-      newValidationError = new Error(`Token amount is more than ${utils.formatUnits(sale?.allocationMax)}`)
+      newValidationError = new Error(
+        `Maximum is ${purchaseMaximumAllocation * tokenPrice} ${sale?.tokenIn.symbol} / ${utils.formatUnits(
+          sale?.allocationMax
+        )} ${sale?.tokenOut.symbol}`
+      )
     }
     // // Purchase value is greater than user's tokeIn balance
     else if (parsedTokenBalance < newPurchaseValue) {
@@ -247,7 +255,7 @@ export const PurchaseTokensForm = ({ saleId }: PurchaseTokensFormComponentProps)
         {validationError ? (
           <PurchaseErrorMessage>{validationError.message}</PurchaseErrorMessage>
         ) : (
-          <SuccessMessage>{`Youll get ${tokenQuantity} ${sale.tokenOut.symbol}`}</SuccessMessage>
+          <SuccessMessage>{`You get ${tokenQuantity} ${sale.tokenOut.symbol}`}</SuccessMessage>
         )}
       </FormGroup>
       <LinkedButtons


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->

Changed logic for calculating value since value is being decided by user.
Instead, it calculated quantity and then checks for errors against both.
Also using a better method (simpler) to do fractional calculations.

Added green text to show quantity of tokens to be received and red text for errors.

FIxed margins on linked button.
Added disable prop for buttons to stop purchases with active error in form.

## Motivation and Context
#241

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Locally buying whole token amount and fractional amounts and testing maths for calculating quantity for different dollar values. Also purchased token to test correct amount of wxdai was removed from wallet.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![2021-06-10 20 40 41](https://user-images.githubusercontent.com/39137239/121586922-23a01e80-ca2c-11eb-8cd3-4d9df9f931e3.png)
![2021-06-10 20 40 59](https://user-images.githubusercontent.com/39137239/121586949-2c90f000-ca2c-11eb-858e-0466d7f344bd.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
