### PR TITLE
refactor sales page and nav bar

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -19,6 +19,7 @@
     "bids": "Bids",
     "graph": "Graph",
     "active": "Active",
+    "live": "Live",
     "closed": "Closed",
     "loading": "Loading",
     "upcoming": "Upcoming",

--- a/src/components/SaleBadge/index.tsx
+++ b/src/components/SaleBadge/index.tsx
@@ -1,9 +1,9 @@
 // External
-
 import styled from 'styled-components'
-import { SpaceProps, TypographyProps, LayoutProps, TextColorProps, FontWeightProps } from 'styled-system'
 
-export type TextBadgeProps = SpaceProps & TypographyProps & LayoutProps & TextColorProps & FontWeightProps
+export type BadgeProps = {
+  active?: boolean
+}
 
 export const BackgroundBadge = styled.div({
   padding: '3px 3px 3px 3px',
@@ -16,27 +16,19 @@ export const BackgroundBadge = styled.div({
   background: '#dddde3',
 })
 
-export const ActiveBadge = styled.div({
+export const Badge = styled.div<BadgeProps>(props => ({
+  cursor: props.active ? 'default' : 'pointer',
   height: '27px',
   width: '95px',
   borderRadius: '33px',
   padding: '5px 13px',
   display: 'flex',
   justifyContent: 'center',
-  background: '#ffffff',
-})
-
-export const TextBadge = styled.p<TextBadgeProps>(props => ({
-  margin: props.color === 'active' ? '0' : '5px 13px',
-  height: '17px',
-  width: props.color === 'active' ? 'auto' : '69px',
-  fontFamily: 'Inter',
   fontSize: '14px',
   fontStyle: 'normal',
-  fontWeight: 500,
+  fontFamily: 'Inter',
   lineHeight: '17px',
-  letterSpacing: '0',
-  textAlign: props.textAlign === 'right' ? 'right' : 'center',
-  color: props.color === 'active' ? '#304ffe' : '#7b7f93',
-  cursor: 'pointer',
+  fontWeight: 500,
+  color: props.active ? '#304ffe' : '#7b7f93',
+  background: props.active ? '#ffffff' : '',
 }))

--- a/src/redux/page/index.ts
+++ b/src/redux/page/index.ts
@@ -4,6 +4,13 @@ import { APP_NAME } from 'src/constants'
 export enum ActionTypes {
   PAGE_SET_TITLE = 'page/title/set',
   PAGE_SET_PATH = 'page/path/set',
+  PAGE_SET_SELECTED_SALE_STATUS = 'PAGE_SET_SELECTED_SALE_STATUS',
+}
+
+export enum SaleStatus {
+  LIVE = 'Live',
+  UPCOMING = 'upcoming',
+  CLOSED = 'closed',
 }
 
 interface PageActionSetTitle extends Action<ActionTypes.PAGE_SET_TITLE> {
@@ -13,12 +20,16 @@ interface PageActionSetTitle extends Action<ActionTypes.PAGE_SET_TITLE> {
 interface PageActionSetPath extends Action<ActionTypes.PAGE_SET_PATH> {
   payload: string
 }
+interface PageActionSetSelectedSaleStatus extends Action<ActionTypes.PAGE_SET_SELECTED_SALE_STATUS> {
+  payload: SaleStatus
+}
 
-type PageAction = PageActionSetTitle | PageActionSetPath
+type PageAction = PageActionSetTitle | PageActionSetPath | PageActionSetSelectedSaleStatus
 
 type PageState = {
   title: string
   path: string
+  selectedSaleStatus: SaleStatus
 }
 
 export const setPagePath = (path: string): PageActionSetPath => ({
@@ -35,17 +46,25 @@ export const setPageTitle = (title: string) => (dispatch: Dispatch) => {
   })
 }
 
-const inititalState: PageState = {
+export const setSelectedSaleStatus = (payload: SaleStatus): PageActionSetSelectedSaleStatus => ({
+  type: ActionTypes.PAGE_SET_SELECTED_SALE_STATUS,
+  payload,
+})
+
+const initialState: PageState = {
   title: 'Home',
   path: '/',
+  selectedSaleStatus: SaleStatus.LIVE,
 }
 
-export function reducer(state: PageState = inititalState, action: PageAction) {
+export function reducer(state: PageState = initialState, action: PageAction) {
   switch (action.type) {
     case ActionTypes.PAGE_SET_TITLE:
       return { ...state, title: action.payload }
     case ActionTypes.PAGE_SET_PATH:
       return { ...state, path: action.payload }
+    case ActionTypes.PAGE_SET_SELECTED_SALE_STATUS:
+      return { ...state, selectedSaleStatus: action.payload }
     default:
       return state
   }

--- a/src/views/Sale/components/PurchaseTokensForm/index.tsx
+++ b/src/views/Sale/components/PurchaseTokensForm/index.tsx
@@ -148,8 +148,6 @@ export const PurchaseTokensForm = ({ saleId }: PurchaseTokensFormComponentProps)
         )} ${sale?.tokenOut.symbol}`
       )
     }
-    console.log({ purchaseMaximumAllocation })
-    console.log({ quantity })
     if (purchaseMaximumAllocation < quantity) {
       newValidationError = new Error(
         `Maximum is ${purchaseMaximumAllocation * tokenPrice} ${sale?.tokenIn.symbol} / ${utils.formatUnits(

--- a/src/views/Sale/components/PurchaseTokensForm/index.tsx
+++ b/src/views/Sale/components/PurchaseTokensForm/index.tsx
@@ -148,6 +148,8 @@ export const PurchaseTokensForm = ({ saleId }: PurchaseTokensFormComponentProps)
         )} ${sale?.tokenOut.symbol}`
       )
     }
+    console.log({ purchaseMaximumAllocation })
+    console.log({ quantity })
     if (purchaseMaximumAllocation < quantity) {
       newValidationError = new Error(
         `Maximum is ${purchaseMaximumAllocation * tokenPrice} ${sale?.tokenIn.symbol} / ${utils.formatUnits(

--- a/src/views/Sales/components/SaleNavBar/index.spec.tsx
+++ b/src/views/Sales/components/SaleNavBar/index.spec.tsx
@@ -1,121 +1,65 @@
 // Externals
-
 import React from 'react'
 import { render, cleanup, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import i18n from 'i18next'
 
 // Components
 import { SaleNavBar } from './index'
-import { SaleContext, SaleStatus, SaleContextType } from '../../index'
+import { SaleStatus } from '../../index'
 
 //clean up
 
 afterEach(cleanup)
+beforeEach(() => {
+  i18n.init({
+    fallbackLng: 'en',
+    react: {
+      useSuspense: false,
+    },
+  })
+})
 
 // helper function
-const wrapper = (sale: SaleContextType) => {
-  return render(
-    <SaleContext.Provider value={sale}>
-      <SaleNavBar />
-    </SaleContext.Provider>
-  )
+const wrapper = (state: SaleStatus, setStatus: (SaleStatus: SaleStatus) => void) => {
+  return render(<SaleNavBar state={state} setStatus={setStatus} />)
 }
 
 describe('testing SaleNavBar', () => {
   test('should display the correct style when SaleStatus is Live', () => {
-    const test: SaleContextType = {
-      SaleShow: SaleStatus.LIVE,
-      setSaleShow: jest.fn(),
-    }
-    const { getByTestId } = wrapper(test)
-    expect(getByTestId('Live')).toHaveTextContent('Live')
+    const { getByTestId } = wrapper(SaleStatus.LIVE, jest.fn())
+    expect(getByTestId('live')).toHaveTextContent('texts.live')
   })
   test('should display the correct style when SaleStatus is Upcoming', () => {
-    const test: SaleContextType = {
-      SaleShow: SaleStatus.UPCOMING,
-      setSaleShow: jest.fn(),
-    }
-    const { getByTestId } = wrapper(test)
-    expect(getByTestId('Upcoming')).toHaveTextContent('Upcoming')
+    const { getByTestId } = wrapper(SaleStatus.UPCOMING, jest.fn())
+    expect(getByTestId('upcoming')).toHaveTextContent('texts.upcoming')
   })
   test('should display the correct style when SaleStatus is Closed', () => {
-    const test: SaleContextType = {
-      SaleShow: SaleStatus.CLOSED,
-      setSaleShow: jest.fn(),
-    }
-    const { getByTestId } = wrapper(test)
-    expect(getByTestId('Closed')).toHaveTextContent('Closed')
+    const { getByTestId } = wrapper(SaleStatus.CLOSED, jest.fn())
+    expect(getByTestId('closed')).toHaveTextContent('texts.closed')
   }),
     test('button should be called when upcoming is clicked when on closed status', async () => {
-      const test: SaleContextType = {
-        SaleShow: SaleStatus.CLOSED,
-        setSaleShow: jest.fn(),
-      }
+      const mock = jest.fn()
+      const { getByTestId } = wrapper(SaleStatus.LIVE, mock)
 
-      const { getByTestId } = wrapper(test)
+      fireEvent.click(getByTestId('closed'))
 
-      fireEvent.click(getByTestId('closedupcomingclick'))
-
-      expect(test.setSaleShow).toHaveBeenCalled()
+      expect(mock).toHaveBeenCalledWith(SaleStatus.CLOSED)
     }),
-    test('button should be called when live is clicked when on upcoming status', async () => {
-      const test: SaleContextType = {
-        SaleShow: SaleStatus.CLOSED,
-        setSaleShow: jest.fn(),
-      }
+    test('button should be called when upcoming is clicked when on closed status', async () => {
+      const mock = jest.fn()
+      const { getByTestId } = wrapper(SaleStatus.CLOSED, mock)
 
-      const { getByTestId } = wrapper(test)
+      fireEvent.click(getByTestId('upcoming'))
 
-      fireEvent.click(getByTestId('closed live click'))
-
-      expect(test.setSaleShow).toHaveBeenCalled()
+      expect(mock).toHaveBeenCalledWith(SaleStatus.UPCOMING)
     }),
-    test('button should be called when closed is clicked when on live status', async () => {
-      const test: SaleContextType = {
-        SaleShow: SaleStatus.LIVE,
-        setSaleShow: jest.fn(),
-      }
+    test('button should be called when upcoming is clicked when on closed status', async () => {
+      const mock = jest.fn()
+      const { getByTestId } = wrapper(SaleStatus.CLOSED, mock)
 
-      const { getByTestId } = wrapper(test)
+      fireEvent.click(getByTestId('live'))
 
-      fireEvent.click(getByTestId('live closed click'))
-
-      expect(test.setSaleShow).toHaveBeenCalled()
-    }),
-    test('button should be called when live is clicked when on upcoming status', async () => {
-      const test: SaleContextType = {
-        SaleShow: SaleStatus.UPCOMING,
-        setSaleShow: jest.fn(),
-      }
-
-      const { getByTestId } = wrapper(test)
-
-      fireEvent.click(getByTestId('upcoming live click'))
-
-      expect(test.setSaleShow).toHaveBeenCalled()
-    }),
-    test('button should be called when upcoming is clicked when on live status', async () => {
-      const test: SaleContextType = {
-        SaleShow: SaleStatus.LIVE,
-        setSaleShow: jest.fn(),
-      }
-
-      const { getByTestId } = wrapper(test)
-
-      fireEvent.click(getByTestId('live upcoming click'))
-
-      expect(test.setSaleShow).toHaveBeenCalled()
-    }),
-    test('button should be called when close is clicked when on upcoming status', async () => {
-      const test: SaleContextType = {
-        SaleShow: SaleStatus.UPCOMING,
-        setSaleShow: jest.fn(),
-      }
-
-      const { getByTestId } = wrapper(test)
-
-      fireEvent.click(getByTestId('upcoming close click'))
-
-      expect(test.setSaleShow).toHaveBeenCalled()
+      expect(mock).toHaveBeenCalledWith(SaleStatus.LIVE)
     })
 })

--- a/src/views/Sales/components/SaleNavBar/index.tsx
+++ b/src/views/Sales/components/SaleNavBar/index.tsx
@@ -1,63 +1,44 @@
 // Externals
-import React, { useContext } from 'react'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
 
 // Components
-import { ActiveBadge, TextBadge, BackgroundBadge } from 'src/components/SaleBadge'
+import { Badge, BackgroundBadge } from 'src/components/SaleBadge'
 
 // context
-import { SaleContext, SaleStatus } from 'src/views/Sales'
+import { SaleStatus } from 'src/views/Sales'
 
-export const SaleNavBar: React.FC = () => {
-  const { SaleShow, setSaleShow } = useContext(SaleContext)
+export interface NavBarProps {
+  state: SaleStatus
+  setStatus: (SaleStatus: SaleStatus) => void
+}
 
-  if (SaleShow === SaleStatus.UPCOMING) {
-    return (
-      <BackgroundBadge>
-        <TextBadge data-testid="upcoming live click" textAlign="left" onClick={() => setSaleShow(SaleStatus.LIVE)}>
-          Live
-        </TextBadge>
-        <ActiveBadge>
-          <TextBadge color="active" data-testid="Upcoming">
-            Upcoming
-          </TextBadge>
-        </ActiveBadge>
-        <TextBadge data-testid="upcoming close click" textAlign="right" onClick={() => setSaleShow(SaleStatus.CLOSED)}>
-          Closed
-        </TextBadge>
-      </BackgroundBadge>
-    )
-  }
+export const SaleNavBar: React.FC<NavBarProps> = ({ state, setStatus }) => {
+  const [t] = useTranslation()
 
-  if (SaleShow === SaleStatus.CLOSED) {
-    return (
-      <BackgroundBadge>
-        <TextBadge data-testid="closed live click" textAlign="left" onClick={() => setSaleShow(SaleStatus.LIVE)}>
-          Live
-        </TextBadge>
-        <TextBadge data-testid="closedupcomingclick" onClick={() => setSaleShow(SaleStatus.UPCOMING)}>
-          Upcoming
-        </TextBadge>
-        <ActiveBadge>
-          <TextBadge color="active" data-testid="Closed">
-            Closed
-          </TextBadge>
-        </ActiveBadge>
-      </BackgroundBadge>
-    )
-  }
   return (
     <BackgroundBadge>
-      <ActiveBadge>
-        <TextBadge color="active" data-testid="Live">
-          Live
-        </TextBadge>
-      </ActiveBadge>
-      <TextBadge data-testid="live upcoming click" onClick={() => setSaleShow(SaleStatus.UPCOMING)}>
-        Upcoming
-      </TextBadge>
-      <TextBadge data-testid="live closed click" textAlign="right" onClick={() => setSaleShow(SaleStatus.CLOSED)}>
-        Closed
-      </TextBadge>
+      <Badge
+        data-testid="live"
+        active={state == SaleStatus.LIVE ? true : false}
+        onClick={() => setStatus(SaleStatus.LIVE)}
+      >
+        {t('texts.live')}
+      </Badge>
+      <Badge
+        data-testid="upcoming"
+        active={state == SaleStatus.UPCOMING ? true : false}
+        onClick={() => setStatus(SaleStatus.UPCOMING)}
+      >
+        {t('texts.upcoming')}
+      </Badge>
+      <Badge
+        data-testid="closed"
+        active={state == SaleStatus.CLOSED ? true : false}
+        onClick={() => setStatus(SaleStatus.CLOSED)}
+      >
+        {t('texts.closed')}
+      </Badge>
     </BackgroundBadge>
   )
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
I refactored quite a lot here to allow the addition of new features and to clean up the code slightly.
Previously context was used to store state but I moved this to redux to retain the state when navigating the app.
It was added to the page object since it is similar to page metadata.

I also refactored how the components are rendered, reducing complexity with fewer conditional statements and repeating code.
To sort the sales I used a useEffect that triggers on status change and is sorted depending on the sale view. 
<!--- Describe your changes in detail -->

## Motivation and Context

#251
#283
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Locally and with unit testing for the nav bar.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
