### PR TITLE
Added requested changes to wording of closed sale

### DIFF
--- a/src/views/Sale/FixedPrice.tsx
+++ b/src/views/Sale/FixedPrice.tsx
@@ -92,7 +92,7 @@ export function FixedPriceSaleView() {
   if (!sale) {
     return <NotFoundView />
   }
-
+  console.log(sale.soldAmount < sale.minimumRaise)
   return (
     <Container minHeight="100%" inner={false} noPadding={true}>
       <Container noPadding>
@@ -149,7 +149,23 @@ export function FixedPriceSaleView() {
                         sale.tokenIn?.symbol
                       }/${sale.tokenOut?.symbol}`}
                     />
-                    <HeaderItem
+                    {isSaleClosed(sale as FIX_LATER) ? (
+                      <HeaderItem
+                        title={sale.soldAmount < sale.minimumRaise ? 'Soft Cap not reached' : 'Amount Sold'}
+                        description={`${formatBigInt(sale.soldAmount)} ${sale.tokenOut?.symbol}`}
+                        error={sale.soldAmount < sale.minimumRaise}
+                      />
+                    ) : (
+                      <HeaderItem
+                        title={'Min. - Max. Allocation'}
+                        description={`${formatBigInt(sale.allocationMin, sale.tokenOut.decimals)} - ${formatBigInt(
+                          sale.allocationMax,
+                          sale.tokenOut.decimals
+                        )} ${sale.tokenOut?.symbol}`}
+                        tooltip={t('texts.minMaxAllocationInfo')}
+                      />
+                    )}
+                    {/* <HeaderItem
                       title={isSaleClosed(sale as FIX_LATER) ? 'Amount Sold' : 'Min. - Max. Allocation'}
                       description={`${formatBigInt(sale.allocationMin, sale.tokenOut.decimals)} - ${formatBigInt(
                         sale.allocationMax,
@@ -157,7 +173,7 @@ export function FixedPriceSaleView() {
                       )} ${sale.tokenOut?.symbol}`}
                       flexAmount={1.5}
                       tooltip={t('texts.minMaxAllocationInfo')}
-                    />
+                    /> */}
                     {(isSaleClosed(sale as FIX_LATER) || isSaleUpcoming(sale as FIX_LATER)) && <Flex flex={0.2} />}
                     {isSaleClosed(sale as FIX_LATER) && (
                       <HeaderItem title="Closed On" description={timeEnd(sale.endDate)} textAlign="right" />

--- a/src/views/Sale/FixedPrice.tsx
+++ b/src/views/Sale/FixedPrice.tsx
@@ -92,7 +92,7 @@ export function FixedPriceSaleView() {
   if (!sale) {
     return <NotFoundView />
   }
-  console.log(sale.soldAmount < sale.minimumRaise)
+
   return (
     <Container minHeight="100%" inner={false} noPadding={true}>
       <Container noPadding>
@@ -165,15 +165,6 @@ export function FixedPriceSaleView() {
                         tooltip={t('texts.minMaxAllocationInfo')}
                       />
                     )}
-                    {/* <HeaderItem
-                      title={isSaleClosed(sale as FIX_LATER) ? 'Amount Sold' : 'Min. - Max. Allocation'}
-                      description={`${formatBigInt(sale.allocationMin, sale.tokenOut.decimals)} - ${formatBigInt(
-                        sale.allocationMax,
-                        sale.tokenOut.decimals
-                      )} ${sale.tokenOut?.symbol}`}
-                      flexAmount={1.5}
-                      tooltip={t('texts.minMaxAllocationInfo')}
-                    /> */}
                     {(isSaleClosed(sale as FIX_LATER) || isSaleUpcoming(sale as FIX_LATER)) && <Flex flex={0.2} />}
                     {isSaleClosed(sale as FIX_LATER) && (
                       <HeaderItem title="Closed On" description={timeEnd(sale.endDate)} textAlign="right" />

--- a/src/views/Sale/components/HeaderControl/index.tsx
+++ b/src/views/Sale/components/HeaderControl/index.tsx
@@ -141,11 +141,13 @@ export function HeaderControl({ status, showGraph, toggleGraph, isFixed, sale }:
     return (
       <Flex flexDirection="column" flex={1}>
         <Flex flexDirection="row" alignItems="center" justifyContent="flex-start" flex={1}>
-          <FixedTitle>Sale Progress</FixedTitle>
+          <FixedTitle>{status === 'closed' ? 'Tokens Sold' : 'Sale Progress'}</FixedTitle>
           <FixedDescription>
             {numeral(amountDisplayed).format('0.[00]')}
             <FixedDescription2>{`(${numeral(percentageSold).format('0.[00]')}%)`}</FixedDescription2>
-            <FixedDescription3>/ {numeral(totalSupply).format('0')}</FixedDescription3>
+            <FixedDescription3>
+              / {numeral(totalSupply).format('0')} {sale.tokenOut.symbol}
+            </FixedDescription3>
             <InfoTooltip>{t('texts.supplyDemandInfo')}</InfoTooltip>
           </FixedDescription>
         </Flex>

--- a/src/views/Sale/components/HeaderItem/index.tsx
+++ b/src/views/Sale/components/HeaderItem/index.tsx
@@ -16,6 +16,9 @@ import { convertUtcTimestampToLocal } from 'src/utils/date'
 type HeaderTitleProps = TypographyProps & {
   color: string
 }
+type HeaderDescProps = TypographyProps & {
+  error?: boolean
+}
 
 const HeaderTitle = styled.div<HeaderTitleProps>(
   props => ({
@@ -28,26 +31,26 @@ const HeaderTitle = styled.div<HeaderTitleProps>(
   typography
 )
 
-const HeaderDescription = styled.div<TypographyProps>(
-  () => ({
+const HeaderDescription = styled.div<HeaderDescProps>(
+  props => ({
     fontStyle: 'normal',
     fontWeight: 'normal',
     fontSize: '24px',
     lineHeight: '29px',
     marginTop: '7px',
     fontFeatureSettings: 'ss01 on',
-    color: '#000629',
+    color: props.error ? '#E15F5F' : '#000629',
   }),
   typography
 )
 
-const MobileHeaderDescription = styled.div<TypographyProps>(
-  () => ({
+const MobileHeaderDescription = styled.div<HeaderDescProps>(
+  props => ({
     fontStyle: 'normal',
     fontWeight: 'normal',
     fontSize: '16px',
     lineHeight: '19px',
-    color: '#000629',
+    color: props.error ? '#E15F5F' : '#000629',
     marginLeft: 'auto',
   }),
   typography
@@ -63,6 +66,7 @@ interface HeaderItemProps {
   sale?: Sale
   flexAmount?: number
   tooltip?: ReactNode
+  error?: boolean
 }
 
 export function HeaderItem({
@@ -74,7 +78,8 @@ export function HeaderItem({
   flexAmount,
   saleLive,
   sale,
-  tooltip
+  tooltip,
+  error = false,
 }: HeaderItemProps) {
   // setting state to update the timer more frequently than the bids
   const [, setTime] = useState<number>(0)
@@ -114,12 +119,14 @@ export function HeaderItem({
         {title} {tooltip && <InfoTooltip>{tooltip}</InfoTooltip>}
       </HeaderTitle>
       {isMobile ? (
-        <MobileHeaderDescription textAlign={textAlign === 'left' ? 'left' : 'right'}>
+        <MobileHeaderDescription textAlign={textAlign === 'left' ? 'left' : 'right'} error={error}>
           {descriptionText}
         </MobileHeaderDescription>
       ) : (
         descriptionText.length > 0 && (
-          <HeaderDescription textAlign={textAlign === 'left' ? 'left' : 'right'}>{descriptionText}</HeaderDescription>
+          <HeaderDescription error={error} textAlign={textAlign === 'left' ? 'left' : 'right'}>
+            {descriptionText}
+          </HeaderDescription>
         )
       )}
     </Flex>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
I added all the requested changes from the original issue.
I think more can be done to make it clear a sale has failed. Maybe a banner might work in future.

Related to the tokenIn/Out issues the soldAmount is in tokenOut and so I have made the UI reflect the current state since it will be fixed soon. (Correcting it to tokenIn now would require more work than just waiting for fix)
The only change to be done to fix this will be changing the symbol to tokenIn.
<!--- Describe your changes in detail -->

## Motivation and Context
#291
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![スクリーンショット 2021-06-28 15 33 18](https://user-images.githubusercontent.com/39137239/123654638-2bcacd00-d826-11eb-84bf-bea924dc3892.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
