### PR TITLE
Changing closed sale summary card

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -30,6 +30,7 @@
     "currentPrice": "Current Price",
     "minPrice": "Minimum Price",
     "amountForSale": "Amount for Sale",
+    "amountSold": "Amount Sold",
     "noBidsMessage": "There are no bids",
     "runningSales": "Running Sales",
     "upcomingSales": "Upcoming Sales",

--- a/src/views/Sales/components/SaleAmount/index.tsx
+++ b/src/views/Sales/components/SaleAmount/index.tsx
@@ -1,6 +1,7 @@
 // Externals
 import React from 'react'
 import numeral from 'numeral'
+import styled from 'styled-components'
 
 // Components
 import { CardText } from 'src/components/CardText'
@@ -11,21 +12,31 @@ import { Sale } from 'src/interfaces/Sale'
 // Mesa utils
 import { formatBigInt } from 'src/utils/Defaults'
 
-interface SaleAmountprops {
+interface SaleAmountProps {
   sale: Sale
+  closed?: boolean
+}
+interface TextProps {
+  closed?: boolean
 }
 
-export const SaleAmount: React.FC<SaleAmountprops> = ({ sale }) => {
+const SaleCardText = styled(CardText)<TextProps>`
+  color: ${props => (props.closed ? 'red' : 'black')};
+`
+
+export const SaleAmount: React.FC<SaleAmountProps> = ({ sale, closed }) => {
   return (
     <Flex>
-      <CardText>
+      <SaleCardText closed={closed}>
         {numeral(
           sale.type == 'FairSale'
             ? formatBigInt(sale.tokenAmount, sale.tokenOut.decimals)
-            : formatBigInt(sale.sellAmount, sale.tokenOut.decimals)
+            : formatBigInt(closed ? sale.soldAmount : sale.sellAmount, sale.tokenOut.decimals)
         ).format('0,0')}
-      </CardText>
-      <CardText fontWeight="light">&nbsp;{sale.tokenOut?.symbol}</CardText>
+      </SaleCardText>
+      <SaleCardText closed={closed} fontWeight="light">
+        &nbsp;{sale.tokenOut?.symbol}
+      </SaleCardText>
     </Flex>
   )
 }

--- a/src/views/Sales/components/SaleAmount/index.tsx
+++ b/src/views/Sales/components/SaleAmount/index.tsx
@@ -17,24 +17,25 @@ interface SaleAmountProps {
   closed?: boolean
 }
 interface TextProps {
-  closed?: boolean
+  isFailed?: boolean
 }
 
 const SaleCardText = styled(CardText)<TextProps>`
-  color: ${props => (props.closed ? 'red' : 'black')};
+  color: ${props => (props.isFailed ? 'red' : 'black')};
 `
 
 export const SaleAmount: React.FC<SaleAmountProps> = ({ sale, closed }) => {
+  const isFailed = sale.soldAmount < sale.minimumRaise && closed
   return (
     <Flex>
-      <SaleCardText closed={closed}>
+      <SaleCardText isFailed={isFailed}>
         {numeral(
           sale.type == 'FairSale'
             ? formatBigInt(sale.tokenAmount, sale.tokenOut.decimals)
             : formatBigInt(closed ? sale.soldAmount : sale.sellAmount, sale.tokenOut.decimals)
         ).format('0,0')}
       </SaleCardText>
-      <SaleCardText closed={closed} fontWeight="light">
+      <SaleCardText isFailed={isFailed} fontWeight="light">
         &nbsp;{sale.tokenOut?.symbol}
       </SaleCardText>
     </Flex>

--- a/src/views/Sales/components/SaleSummaryCard/index.tsx
+++ b/src/views/Sales/components/SaleSummaryCard/index.tsx
@@ -21,6 +21,7 @@ import { Sale } from 'src/interfaces/Sale'
 
 // Svg
 import noToken from 'src/assets/svg/no-token-image.svg'
+import { isSaleClosed } from 'src/mesa/sale'
 
 interface SaleSummaryProps {
   sale: Sale
@@ -48,14 +49,25 @@ export function SaleSummaryCard({ sale }: SaleSummaryProps) {
             <CardText color="grey">{t('texts.salesType')}</CardText>
             {sale.type == 'FixedPriceSale' ? <CardText>Fixed Price Sale</CardText> : <CardText>Fair Sale</CardText>}
           </Flex>
-          <Flex flexDirection="row" justifyContent="space-between">
-            <CardText color="grey">{t('texts.currentPrice')}</CardText>
-            <SaleFinalPrice sale={sale} />
-          </Flex>
-          <Flex flexDirection="row" justifyContent="space-between">
-            <CardText color="grey">{t('texts.amountForSale')}</CardText>
-            <SaleAmount sale={sale} />
-          </Flex>
+          {isSaleClosed(sale) ? (
+            <Flex flexDirection="row" justifyContent="space-between">
+              <CardText color="grey">{t('texts.amountSold')}</CardText>
+              <SaleAmount closed sale={sale} />
+            </Flex>
+          ) : (
+            <div>
+              <Flex flexDirection="row" justifyContent="space-between">
+                <CardText color="grey">{t('texts.currentPrice')}</CardText>
+                <SaleFinalPrice sale={sale} />
+              </Flex>
+
+              <Flex flexDirection="row" justifyContent="space-between">
+                <CardText color="grey">{t('texts.amountForSale')}</CardText>
+                <SaleAmount sale={sale} />
+              </Flex>
+            </div>
+          )}
+
           <SaleClock sale={sale} />
         </Flex>
       </CardBody>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
I used the figma designs to change the closed sale summary cards to display the amount sold.
This will need changed with new SCs to show in WXDAI/tokenIn.
Also added red text like in the sale to show failed sales.
In future we could have a better way of displaying failed sales but for now this works.

<!--- Describe your changes in detail -->

## Motivation and Context
#317 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="1041" alt="スクリーンショット 2021-07-06 11 20 49" src="https://user-images.githubusercontent.com/39137239/124584495-3a2f6f00-de4c-11eb-9510-18235bfcdacf.png">
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
