### PR TITLE
Fixing amount for sale for live sale cards

### DIFF
--- a/src/views/Sales/components/SaleAmount/index.tsx
+++ b/src/views/Sales/components/SaleAmount/index.tsx
@@ -26,15 +26,20 @@ const SaleCardText = styled(CardText)<TextProps>`
 
 export const SaleAmount: React.FC<SaleAmountProps> = ({ sale, closed }) => {
   const isFailed = sale.soldAmount < sale.minimumRaise && closed
+  // Due to subgraph issue amount starts at 0 then is set to remaining supply
   return (
     <Flex>
       <SaleCardText isFailed={isFailed}>
         {numeral(
           sale.type == 'FairSale'
             ? formatBigInt(sale.tokensForSale, sale.tokenOut.decimals)
+            : closed
+            ? formatBigInt(sale.soldAmount) == 0
+              ? 0
+              : fixRounding(formatBigInt(sale.sellAmount) - formatBigInt(sale.soldAmount), 8)
             : formatBigInt(sale.soldAmount) == 0
-            ? 0
-            : fixRounding(formatBigInt(sale.sellAmount) - formatBigInt(sale.soldAmount), 8)
+            ? formatBigInt(sale.sellAmount)
+            : formatBigInt(sale.soldAmount)
         ).format('0,0')}
       </SaleCardText>
       <SaleCardText isFailed={isFailed} fontWeight="light">


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Just something I missed when updating to 0.1.1
Cards should now show 
The reason this is slightly complex is because of an issue with the subgraph that Adam plans on fixing but for now this works.
The issue is that soldAmount goes from 0 with no sales to the remaining amount of tokens left after bids are totalled. This is a little confusing for the variable name and should be fixed at some point
<!--- Describe your changes in detail -->

## Motivation and Context


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="1124" alt="スクリーンショット 2021-07-30 16 13 33" src="https://user-images.githubusercontent.com/39137239/127674108-5bfb8a4e-4c74-4269-b3a7-b2321029fde9.png">
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
