### PR TITLE
Adding more accuracy to progress bar for clarity

### DIFF
--- a/src/views/Sale/components/HeaderControl/index.tsx
+++ b/src/views/Sale/components/HeaderControl/index.tsx
@@ -137,7 +137,7 @@ export function HeaderControl({ status, showGraph, toggleGraph, isFixed, sale }:
         <Flex flexDirection="row" alignItems="center" justifyContent="flex-start" flex={1}>
           <FixedTitle>{status === 'closed' ? 'Tokens Sold' : 'Sale Progress'}</FixedTitle>
           <FixedDescription>
-            {numeral(totalAmountPurchased).format('0.[00]')}
+            {numeral(totalAmountPurchased).format('0.[0000000]')}
             <FixedDescription2>{`(${numeral(percentageSold).format('0.[00]')}%)`}</FixedDescription2>
             <FixedDescription3>
               / {numeral(totalSupply).format('0')} {sale.tokenOut.symbol}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Geronimo identified what looked like a rounding error caused by commitments of roughly 0.00011 of a token. 
To in future avoid rare confusions like this we can show additional accuracy in the progress bar for tokens sold.
See issue for more detail of the original issue
<!--- Describe your changes in detail -->

## Motivation and Context
Closes #401
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Change showing accuracy:
<img width="624" alt="スクリーンショット 2021-08-13 16 27 07" src="https://user-images.githubusercontent.com/39137239/129382365-8e44f928-c7b7-4367-8800-31f29416bcbd.png">

Additional zeros dont show up when not needed:
<img width="1042" alt="スクリーンショット 2021-08-13 16 27 24" src="https://user-images.githubusercontent.com/39137239/129382412-4b8f9e62-298b-49d2-850e-27c44327eafd.png">

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
