### PR TITLE
Fix fair sale display in the summary cards.

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -31,6 +31,8 @@
     "otherSales": "Other Sales",
     "placeBid": "Place Bid",
     "salesType": "Sales Type",
+    "fairSale": "Fair Sale",
+    "fixedPriceSale": "Fixed Price Sale",
     "currentPrice": "Current Price",
     "minPrice": "Minimum Price",
     "amountForSale": "Amount for Sale",

--- a/src/views/Sales/components/SaleSummaryCard/index.tsx
+++ b/src/views/Sales/components/SaleSummaryCard/index.tsx
@@ -51,7 +51,7 @@ export function SaleSummaryCard({ sale, purchaseAmount }: SaleSummaryProps) {
         <Flex flexDirection="column" justifyContent="space-evenly" height="75%" margin="12px 0 0 0">
           <Flex flexDirection="row" justifyContent="space-between">
             <CardText color="grey">{t('texts.salesType')}</CardText>
-            <CardText>Fixed Price Sale</CardText>
+            <CardText>{sale?.__typename == "FixedPriceSale" ? t('texts.fixedPriceSale') : t('texts.fairSale')}</CardText>
           </Flex>
           {isSaleClosed(sale) ? (
             <Flex flexDirection="row" justifyContent="space-between">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Label fair sales as such on the summary cards.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #364.

Fair sales are already visible on the sales view, but were mislabeled.

It should be noted that the current price displayed is incorrect, and will need fixing once we have actual fair sales deployed. I opened #439 to track this.

## How Has This Been Tested?

Tested locally, with mock data.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/25136207/130802564-8b6986c8-80e7-49b8-8053-0816d6f3566c.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
